### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ dependencies {
   // (...)
 }
 ```
-##RN >= 0.29
+## RN >= 0.29
 
 *MainApplication.java*
 ```Java
@@ -101,7 +101,7 @@ protected List<ReactPackage> getPackages() {
 }
 ```
 
-##RN < 0.28
+## RN < 0.28
 
 *MainApplication.java*
 ```Java


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
