### PR TITLE
fix: removing createJSModules @Override marker

### DIFF
--- a/android/src/main/java/com/centaurwarchief/smslistener/SmsListenerPackage.java
+++ b/android/src/main/java/com/centaurwarchief/smslistener/SmsListenerPackage.java
@@ -22,7 +22,7 @@ public class SmsListenerPackage implements ReactPackage {
         );
     }
 
-    @Override
+    // @Override deprecated in RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
this change handles RN 0.47 breaking change related to createJSModules: https://github.com/facebook/react-native/releases/tag/v0.47.0

resolves #21 