### PR TITLE
Update build.gradle file for RN 0.56 support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,18 +1,17 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.facebook.react:react-native:0.20.+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Latest version of react native requires android apps to use SDK version 26. This pull request contains the bumped up SDK version numbers and tested working on android 7, 8  and 9.

Fixes https://github.com/CentaurWarchief/react-native-android-sms-listener/issues/35