### PR TITLE
Handle multipart messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ The contents of `message` object will be:
 ```JS
 {
   originatingAddress: string,
-  body: string
+  body: string,
+  timestamp: number
 }
 ```
 


### PR DESCRIPTION
If incoming message is too long, current version of the library emits multiple events with chunked message body. This PR adds handling multipart messages by combining all parts together. It also adds "timestamp" info to the emitted event