### PR TITLE
fix add listener multiple times and commented code to keep listener work in background / foreground

### DIFF
--- a/android/src/main/java/com/centaurwarchief/smslistener/SmsListenerModule.java
+++ b/android/src/main/java/com/centaurwarchief/smslistener/SmsListenerModule.java
@@ -59,12 +59,12 @@ public class SmsListenerModule extends ReactContextBaseJavaModule implements Lif
 
     @Override
     public void onHostPause() {
-        unregisterReceiver(mReceiver);
+        // unregisterReceiver(mReceiver);
     }
 
     @Override
     public void onHostDestroy() {
-        unregisterReceiver(mReceiver);
+        // unregisterReceiver(mReceiver);
     }
 
     @Override

--- a/android/src/main/java/com/centaurwarchief/smslistener/SmsListenerModule.java
+++ b/android/src/main/java/com/centaurwarchief/smslistener/SmsListenerModule.java
@@ -23,21 +23,24 @@ public class SmsListenerModule extends ReactContextBaseJavaModule implements Lif
     }
 
     private void registerReceiverIfNecessary(BroadcastReceiver receiver) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && getCurrentActivity() != null) {
-            getCurrentActivity().registerReceiver(
-                receiver,
-                new IntentFilter(Telephony.Sms.Intents.SMS_RECEIVED_ACTION)
-            );
-            isReceiverRegistered = true;
-            return;
-        }
-
-        if (getCurrentActivity() != null) {
-            getCurrentActivity().registerReceiver(
+        // register only once if it's not registered
+        if(!isReceiverRegistered) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && getCurrentActivity() != null) {
+                getCurrentActivity().registerReceiver(
                     receiver,
-                    new IntentFilter("android.provider.Telephony.SMS_RECEIVED")
-            );
-            isReceiverRegistered = true;
+                    new IntentFilter(Telephony.Sms.Intents.SMS_RECEIVED_ACTION)
+                );
+                isReceiverRegistered = true;
+                return;
+            }
+
+            if (getCurrentActivity() != null) {
+                getCurrentActivity().registerReceiver(
+                        receiver,
+                        new IntentFilter("android.provider.Telephony.SMS_RECEIVED")
+                );
+                isReceiverRegistered = true;
+            }
         }
     }
 
@@ -50,6 +53,7 @@ public class SmsListenerModule extends ReactContextBaseJavaModule implements Lif
 
     @Override
     public void onHostResume() {
+        // stop call `registerReceiverIfNecessary` when host resume because it's will call the listener multiple times there's an already condition added but that maybe not necessary here
         registerReceiverIfNecessary(mReceiver);
     }
 


### PR DESCRIPTION
- fix adding listener multiple times each time open the app while run foreground service together with the package
- stop call `unregisterReceiver` inside `onHostPause` and `onHostDestroy` handlers to keep the listener work with background or foreground service